### PR TITLE
8-bit audio stream

### DIFF
--- a/GBAMusicStudio/Config.yaml
+++ b/GBAMusicStudio/Config.yaml
@@ -1,8 +1,6 @@
 # These cannot be refreshed in the program:
 
 DirectCount: 24 # 5 or above.
-Volume: 50 # 0 to 100.
-SampleRate: 48000 # Must be a multiple of 60 or else you will get bad audio.
 
 # These can be refreshed in the program:
 

--- a/GBAMusicStudio/Core/Config.cs
+++ b/GBAMusicStudio/Core/Config.cs
@@ -118,7 +118,6 @@ namespace Kermalis.GBAMusicStudio.Core
         readonly int DefaultTableSize = 1000;
 
         public byte DirectCount { get; private set; }
-        public int SampleRate { get; private set; }
         public bool All256Voices { get; private set; }
         public bool MIDIKeyboardFixedVelocity { get; private set; }
         public bool TaskbarProgress { get; private set; }
@@ -128,7 +127,6 @@ namespace Kermalis.GBAMusicStudio.Core
         public PlaylistMode PlaylistMode { get; private set; }
         public byte PlaylistSongLoops { get; private set; }
         public int PlaylistFadeOutLength { get; private set; }
-        public byte Volume { get; private set; }
         public HSLColor[] Colors { get; private set; }
         public Dictionary<string, ARemap> InstrumentRemaps { get; private set; }
 
@@ -143,7 +141,6 @@ namespace Kermalis.GBAMusicStudio.Core
 
             var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
             DirectCount = (byte)Utils.ParseValue(mapping.Children["DirectCount"].ToString());
-            SampleRate = (int)Utils.ParseValue(mapping.Children["SampleRate"].ToString());
             All256Voices = bool.Parse(mapping.Children["All256Voices"].ToString());
             MIDIKeyboardFixedVelocity = bool.Parse(mapping.Children["MIDIKeyboardFixedVelocity"].ToString());
             TaskbarProgress = bool.Parse(mapping.Children["TaskbarProgress"].ToString());
@@ -153,7 +150,6 @@ namespace Kermalis.GBAMusicStudio.Core
             PlaylistMode = (PlaylistMode)Enum.Parse(typeof(PlaylistMode), mapping.Children["PlaylistMode"].ToString());
             PlaylistSongLoops = (byte)Utils.ParseValue(mapping.Children["PlaylistSongLoops"].ToString());
             PlaylistFadeOutLength = (int)Utils.ParseValue(mapping.Children["PlaylistFadeOutLength"].ToString());
-            Volume = (byte)Utils.ParseValue(mapping.Children["Volume"].ToString());
 
             var cmap = (YamlMappingNode)mapping.Children["Colors"];
             Colors = new HSLColor[256];

--- a/GBAMusicStudio/Core/Config.cs
+++ b/GBAMusicStudio/Core/Config.cs
@@ -173,11 +173,11 @@ namespace Kermalis.GBAMusicStudio.Core
                         l = byte.Parse(v.Value.ToString());
                     }
                 }
-                HSLColor color = new HSLColor(h, s, l);
+                var color = new HSLColor(h, s, l);
                 Colors[i] = Colors[i + 0x80] = color;
             }
 
-            YamlMappingNode rmap = (YamlMappingNode)mapping.Children["InstrumentRemaps"];
+            var rmap = (YamlMappingNode)mapping.Children["InstrumentRemaps"];
             InstrumentRemaps = new Dictionary<string, ARemap>();
             foreach (KeyValuePair<YamlNode, YamlNode> r in rmap)
             {

--- a/GBAMusicStudio/Core/Engine.cs
+++ b/GBAMusicStudio/Core/Engine.cs
@@ -6,7 +6,8 @@ namespace Kermalis.GBAMusicStudio.Core
 {
     static class Engine
     {
-        public const int BPM_PER_FRAME = 150, AGB_FPS = 60;
+        public const int BPM_PER_FRAME = 150;
+        public const double AGB_FPS = 59.7275;
         static readonly Exception BAD = new PlatformNotSupportedException("Invalid game engine.");
 
         static readonly Dictionary<EngineType, ICommand[]> allowedCommands;

--- a/GBAMusicStudio/Core/Reverb.cs
+++ b/GBAMusicStudio/Core/Reverb.cs
@@ -5,8 +5,8 @@ namespace Kermalis.GBAMusicStudio.Core
     // All of this was written in C++ by ipatix; I just converted it
     class Reverb
     {
-        protected readonly float[] reverbBuffer;
-        protected readonly float intensity;
+        protected readonly byte[] reverbBuffer;
+        protected readonly byte intensity;
         protected readonly int bufferLen;
         protected int bufferPos1, bufferPos2;
 
@@ -14,11 +14,11 @@ namespace Kermalis.GBAMusicStudio.Core
         {
             bufferLen = (int)(ROM.Instance.Game.Engine.Frequency / Engine.AGB_FPS);
             bufferPos2 = bufferLen;
-            this.intensity = intensity / (float)0x80;
-            reverbBuffer = new float[bufferLen * 2 * numBuffers];
+            this.intensity = intensity;
+            reverbBuffer = new byte[bufferLen * 2 * numBuffers];
         }
 
-        public void Process(float[] buffer, int samplesPerBuffer)
+        public void Process(byte[] buffer, int samplesPerBuffer)
         {
             int index = 0;
             while (samplesPerBuffer > 0)
@@ -29,7 +29,7 @@ namespace Kermalis.GBAMusicStudio.Core
             }
         }
 
-        protected virtual int Process(float[] buffer, int samplesPerBuffer, ref int index)
+        protected virtual int Process(byte[] buffer, int samplesPerBuffer, ref int index)
         {
             int rSamplesPerBuffer = reverbBuffer.Length / 2;
 
@@ -37,13 +37,12 @@ namespace Kermalis.GBAMusicStudio.Core
                 Math.Min(rSamplesPerBuffer - bufferPos1, rSamplesPerBuffer - bufferPos2),
                 samplesPerBuffer
                 );
-            bool reset1 = (rSamplesPerBuffer - bufferPos1 == count),
-                reset2 = (rSamplesPerBuffer - bufferPos2 == count);
+            bool reset1 = rSamplesPerBuffer - bufferPos1 == count,
+                reset2 = rSamplesPerBuffer - bufferPos2 == count;
             int c = count;
             do
             {
-                float rev = (reverbBuffer[bufferPos1 * 2] * 2
-                    + reverbBuffer[bufferPos1 * 2 + 1] * 2) * intensity / 4;
+                byte rev = (byte)(((reverbBuffer[bufferPos1 * 2] * 2) + (reverbBuffer[(bufferPos1 * 2) + 1] * 2)) * intensity / 0x200);
 
                 reverbBuffer[bufferPos1 * 2] = buffer[index++] += rev;
                 reverbBuffer[bufferPos1 * 2 + 1] = buffer[index++] += rev;
@@ -63,14 +62,14 @@ namespace Kermalis.GBAMusicStudio.Core
 
     class ReverbCamelot1 : Reverb
     {
-        float[] cBuffer;
+        byte[] cBuffer;
         public ReverbCamelot1(byte intensity, byte numBuffers) : base(intensity, numBuffers)
         {
             bufferPos2 = 0;
-            cBuffer = new float[bufferLen * 2];
+            cBuffer = new byte[bufferLen * 2];
         }
 
-        protected override int Process(float[] buffer, int samplesPerBuffer, ref int index)
+        protected override int Process(byte[] buffer, int samplesPerBuffer, ref int index)
         {
             int rSamplesPerBuffer = reverbBuffer.Length / 2;
             int cSamplesPerBuffer = cBuffer.Length / 2;
@@ -78,22 +77,22 @@ namespace Kermalis.GBAMusicStudio.Core
                 Math.Min(rSamplesPerBuffer - bufferPos1, cSamplesPerBuffer - bufferPos2),
                 samplesPerBuffer
                 );
-            bool reset1 = (count == rSamplesPerBuffer - bufferPos1),
-                resetC = (count == cSamplesPerBuffer - bufferPos2);
+            bool reset1 = count == rSamplesPerBuffer - bufferPos1,
+                resetC = count == cSamplesPerBuffer - bufferPos2;
             int c = count;
             do
             {
-                float mixL = buffer[index] + cBuffer[bufferPos2 * 2];
-                float mixR = buffer[index + 1] + cBuffer[bufferPos2 * 2 + 1];
+                byte mixL = (byte)(buffer[index] + cBuffer[bufferPos2 * 2]);
+                byte mixR = (byte)(buffer[index + 1] + cBuffer[bufferPos2 * 2 + 1]);
 
-                float lA = reverbBuffer[bufferPos1 * 2];
-                float rA = reverbBuffer[bufferPos1 * 2 + 1];
+                byte lA = reverbBuffer[bufferPos1 * 2];
+                byte rA = reverbBuffer[bufferPos1 * 2 + 1];
 
                 buffer[index] = reverbBuffer[bufferPos1 * 2] = mixL;
                 buffer[index + 1] = reverbBuffer[bufferPos1 * 2 + 1] = mixR;
 
-                float lRMix = mixL / 4f + rA / 4f;
-                float rRMix = mixR / 4f + lA / 4f;
+                byte lRMix = (byte)((mixL / 4) + (rA / 4));
+                byte rRMix = (byte)((mixR / 4) + (lA / 4));
 
                 cBuffer[bufferPos2 * 2] = lRMix;
                 cBuffer[bufferPos2 * 2 + 1] = rRMix;
@@ -114,48 +113,48 @@ namespace Kermalis.GBAMusicStudio.Core
         }
     }
 
-    internal class ReverbCamelot2 : Reverb
+    class ReverbCamelot2 : Reverb
     {
-        float[] cBuffer; int cPos;
+        byte[] cBuffer; int cPos;
         readonly float primary, secondary;
         internal ReverbCamelot2(byte intensity, byte numBuffers, float primary, float secondary) : base(intensity, numBuffers)
         {
-            cBuffer = new float[bufferLen * 2];
+            cBuffer = new byte[bufferLen * 2];
             bufferPos2 = reverbBuffer.Length / 2 - (cBuffer.Length / 2 / 3);
             this.primary = primary; this.secondary = secondary;
         }
 
-        protected override int Process(float[] buffer, int samplesPerBuffer, ref int index)
+        protected override int Process(byte[] buffer, int samplesPerBuffer, ref int index)
         {
             int rSamplesPerBuffer = reverbBuffer.Length / 2;
             int count = Math.Min(
                     Math.Min(rSamplesPerBuffer - bufferPos1, rSamplesPerBuffer - bufferPos2),
                     Math.Min(samplesPerBuffer, cBuffer.Length / 2 - cPos)
                     );
-            bool reset = (rSamplesPerBuffer - bufferPos1 == count),
-                reset2 = (rSamplesPerBuffer - bufferPos2 == count),
-                resetC = (cBuffer.Length / 2 - cPos == count);
+            bool reset = rSamplesPerBuffer - bufferPos1 == count,
+                reset2 = rSamplesPerBuffer - bufferPos2 == count,
+                resetC = (cBuffer.Length / 2) - cPos == count;
 
             int c = count;
             do
             {
-                float mixL = buffer[index] + cBuffer[cPos * 2];
-                float mixR = buffer[index + 1] + cBuffer[cPos * 2 + 1];
+                byte mixL = (byte)(buffer[index] + cBuffer[cPos * 2]);
+                byte mixR = (byte)(buffer[index + 1] + cBuffer[cPos * 2 + 1]);
 
-                float lA = reverbBuffer[bufferPos1 * 2];
-                float rA = reverbBuffer[bufferPos1 * 2 + 1];
+                byte lA = reverbBuffer[bufferPos1 * 2];
+                byte rA = reverbBuffer[bufferPos1 * 2 + 1];
 
                 buffer[index] = reverbBuffer[bufferPos1 * 2] = mixL;
                 buffer[index + 1] = reverbBuffer[bufferPos1 * 2 + 1] = mixR;
 
-                float lRMix = lA * primary + rA * secondary;
-                float rRMix = rA * primary + lA * secondary;
+                byte lRMix = (byte)((byte)(lA * primary) + (byte)(rA * secondary));
+                byte rRMix = (byte)((byte)(rA * primary) + (byte)(lA * secondary));
 
-                float lB = reverbBuffer[bufferPos2 * 2 + 1] / 4f;
-                float rB = mixR / 4f;
+                byte lB = (byte)(reverbBuffer[bufferPos2 * 2 + 1] / 4);
+                byte rB = (byte)(mixR / 4);
 
-                cBuffer[cPos * 2] = lRMix + lB;
-                cBuffer[cPos * 2 + 1] = rRMix + rB;
+                cBuffer[cPos * 2] = (byte)(lRMix + lB);
+                cBuffer[cPos * 2 + 1] = (byte)(rRMix + rB);
 
                 index += 2;
                 bufferPos1++; bufferPos2++; cPos++;

--- a/GBAMusicStudio/Core/Reverb.cs
+++ b/GBAMusicStudio/Core/Reverb.cs
@@ -12,7 +12,7 @@ namespace Kermalis.GBAMusicStudio.Core
 
         public Reverb(byte intensity, byte numBuffers)
         {
-            bufferLen = Config.Instance.SampleRate / Engine.AGB_FPS;
+            bufferLen = (int)(ROM.Instance.Game.Engine.Frequency / Engine.AGB_FPS);
             bufferPos2 = bufferLen;
             this.intensity = intensity / (float)0x80;
             reverbBuffer = new float[bufferLen * 2 * numBuffers];

--- a/GBAMusicStudio/Core/Samples.cs
+++ b/GBAMusicStudio/Core/Samples.cs
@@ -7,10 +7,10 @@ namespace Kermalis.GBAMusicStudio.Core
     static class Samples
     {
         // Squares
-        public static float[] SquareD12 = new float[] { 0.50f, 0.50f, 0.50f, 0.50f, -0.50f, -0.50f, -0.50f, -0.50f };
-        public static float[] SquareD25 = new float[] { 0.875f, -0.125f, -0.125f, -0.125f, -0.125f, -0.125f, -0.125f, -0.125f };
-        public static float[] SquareD50 = new float[] { 0.75f, 0.75f, -0.25f, -0.25f, -0.25f, -0.25f, -0.25f, -0.25f };
-        public static float[] SquareD75 = new float[] { 0.25f, 0.25f, 0.25f, 0.25f, 0.25f, 0.25f, -0.75f, -0.75f };
+        public static byte[] SquareD12 = new byte[] { 0xC0, 0xC0, 0xC0, 0xC0, 0x40, 0x40, 0x40, 0x40 };
+        public static byte[] SquareD25 = new byte[] { 0xF0, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70, 0x70 };
+        public static byte[] SquareD50 = new byte[] { 0xE0, 0xE0, 0x60, 0x60, 0x60, 0x60, 0x60, 0x60 };
+        public static byte[] SquareD75 = new byte[] { 0xA0, 0xA0, 0xA0, 0xA0, 0xA0, 0xA0, 0x20, 0x20 };
 
         // Noises
         static BitArray noiseFine = null, noiseRough = null;
@@ -67,25 +67,19 @@ namespace Kermalis.GBAMusicStudio.Core
             }
         }
 
-        public static float[] PCM4ToFloat(int address)
+        public static byte[] PCM4ToPCM8(int address)
         {
-            var sample = new float[0x20];
+            var sample = new byte[0x20];
 
             byte[] data = ROM.Instance.Reader.ReadBytes(0x10, address);
-            float sum = 0;
             for (int i = 0; i < 0x10; i++)
             {
                 byte b = data[i];
-                float first = (b >> 4) / 16f;
-                float second = (b & 0xF) / 16f;
-                sum += sample[i * 2] = first;
-                sum += sample[i * 2 + 1] = second;
+                sample[i * 2] = (byte)((b >> 4) * 17);
+                sample[i * 2 + 1] = (byte)((b & 0xF) * 17);
             }
-            float dcCorrection = sum / 0x20;
-            for (int i = 0; i < 0x20; i++)
-            {
-                sample[i] -= dcCorrection;
-            }
+
+            // TODO: Bring back correction? It gets really loud in some songs now
 
             return sample;
         }
@@ -106,7 +100,7 @@ namespace Kermalis.GBAMusicStudio.Core
         public static readonly sbyte[] CompressionLookup = { 0, 1, 4, 9, 16, 25, 36, 49, -64, -49, -36, -25, -16, -9, -4, -1 };
         public static sbyte[] Decompress(WrappedSample sample)
         {
-            List<sbyte> samples = new List<sbyte>();
+            var samples = new List<sbyte>();
             sbyte compressionLevel = 0;
             int compressionByte = 0, compressionIdx = 0;
 

--- a/GBAMusicStudio/Core/SoundMixer.cs
+++ b/GBAMusicStudio/Core/SoundMixer.cs
@@ -259,7 +259,7 @@ namespace Kermalis.GBAMusicStudio.Core
             // Reverb only applies to DirectSound
             for (int i = 0; i < numTracks; i++)
             {
-                //reverbs[i]?.Process(trackBuffers[i], SamplesPerBuffer);
+                reverbs[i]?.Process(trackBuffers[i], SamplesPerBuffer);
             }
 
             for (int i = 0; i < gbChannels.Length; i++)

--- a/GBAMusicStudio/Core/VoiceTableSaver.cs
+++ b/GBAMusicStudio/Core/VoiceTableSaver.cs
@@ -31,8 +31,8 @@ namespace Kermalis.GBAMusicStudio.Core
         {
             switch (ROM.Instance.Game.Engine.Type)
             {
-                case EngineType.M4A: new M4AVoiceTableSaver(fileName, false); return;
-                case EngineType.MLSS: new MLSSVoiceTableSaver(fileName); return;
+                //case EngineType.M4A: new M4AVoiceTableSaver(fileName, false); return;
+                //case EngineType.MLSS: new MLSSVoiceTableSaver(fileName); return;
                 default: throw new PlatformNotSupportedException("Exporting to SF2 from this game engine is not supported at this time.");
             }
         }
@@ -42,7 +42,7 @@ namespace Kermalis.GBAMusicStudio.Core
             sf2.InfoChunk.Copyright = ROM.Instance.Game.Creator;
             sf2.InfoChunk.Tools = "GBA Music Studio by Kermalis";
         }
-
+        /*
         private class M4AVoiceTableSaver
         {
             readonly SF2 sf2;
@@ -323,7 +323,7 @@ namespace Kermalis.GBAMusicStudio.Core
                 }
                 savedSamples.Add(address);
 
-                float[] ieee = Samples.PCM4ToFloat(address);
+                float[] ieee = Samples.PCM4ToPCM8(address);
                 short[] pcm16 = Samples.FloatToPCM16(ieee);
                 return (int)sf2.AddSample(pcm16, string.Format("Wave 0x{0:X7}", address), true, 0, 7040, 69, 0);
             }
@@ -450,5 +450,6 @@ namespace Kermalis.GBAMusicStudio.Core
                 }
             }
         }
+        */
     }
 }

--- a/GBAMusicStudio/Program.cs
+++ b/GBAMusicStudio/Program.cs
@@ -16,7 +16,7 @@ namespace Kermalis.GBAMusicStudio
 
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new UI.MainForm());
+            Application.Run(UI.MainForm.Instance);
 
             // Bad coding that I have to include the following line, but I legitimately don't know why a system thread was remaining alive
             Environment.Exit(0);

--- a/GBAMusicStudio/Program.cs
+++ b/GBAMusicStudio/Program.cs
@@ -15,7 +15,6 @@ namespace Kermalis.GBAMusicStudio
             Console.WriteLine("UI Culture: {0}", Thread.CurrentThread.CurrentUICulture);
 
             Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(UI.MainForm.Instance);
 
             // Bad coding that I have to include the following line, but I legitimately don't know why a system thread was remaining alive

--- a/GBAMusicStudio/UI/AssemblerDialog.cs
+++ b/GBAMusicStudio/UI/AssemblerDialog.cs
@@ -95,7 +95,7 @@ namespace Kermalis.GBAMusicStudio.UI
         }
         void PreviewSong(object sender, EventArgs e)
         {
-            ((MainForm)Owner).PreviewSong(song, Path.GetFileName(assembler.FileName));
+            MainForm.Instance.PreviewSong(song, Path.GetFileName(assembler.FileName));
         }
         void OpenASM(object sender, EventArgs e)
         {

--- a/GBAMusicStudio/UI/FlexibleMessageBox.cs
+++ b/GBAMusicStudio/UI/FlexibleMessageBox.cs
@@ -176,124 +176,123 @@ namespace Kermalis.GBAMusicStudio.UI
             }
             void InitializeComponent()
             {
-                this.components = new Container();
-                this.button1 = new ThemedButton();
-                this.richTextBoxMessage = new ThemedRichTextBox();
-                this.FlexibleMessageBoxFormBindingSource = new BindingSource(this.components);
-                this.panel1 = new ThemedPanel();
-                this.pictureBoxForIcon = new PictureBox();
-                this.button2 = new ThemedButton();
-                this.button3 = new ThemedButton();
-                ((ISupportInitialize)(this.FlexibleMessageBoxFormBindingSource)).BeginInit();
-                this.panel1.SuspendLayout();
-                ((ISupportInitialize)(this.pictureBoxForIcon)).BeginInit();
-                this.SuspendLayout();
+                components = new Container();
+                button1 = new ThemedButton();
+                richTextBoxMessage = new ThemedRichTextBox();
+                FlexibleMessageBoxFormBindingSource = new BindingSource(components);
+                panel1 = new ThemedPanel();
+                pictureBoxForIcon = new PictureBox();
+                button2 = new ThemedButton();
+                button3 = new ThemedButton();
+                ((ISupportInitialize)(FlexibleMessageBoxFormBindingSource)).BeginInit();
+                panel1.SuspendLayout();
+                ((ISupportInitialize)(pictureBoxForIcon)).BeginInit();
+                SuspendLayout();
                 // 
                 // button1
                 // 
-                this.button1.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-                this.button1.AutoSize = true;
-                this.button1.DialogResult = DialogResult.OK;
-                this.button1.Location = new Point(11, 67);
-                this.button1.MinimumSize = new Size(0, 24);
-                this.button1.Name = "button1";
-                this.button1.Size = new Size(75, 24);
-                this.button1.TabIndex = 2;
-                this.button1.Text = "OK";
-                this.button1.UseVisualStyleBackColor = true;
-                this.button1.Visible = false;
+                button1.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                button1.AutoSize = true;
+                button1.DialogResult = DialogResult.OK;
+                button1.Location = new Point(11, 67);
+                button1.MinimumSize = new Size(0, 24);
+                button1.Name = "button1";
+                button1.Size = new Size(75, 24);
+                button1.TabIndex = 2;
+                button1.Text = "OK";
+                button1.UseVisualStyleBackColor = true;
+                button1.Visible = false;
                 // 
                 // richTextBoxMessage
                 // 
-                this.richTextBoxMessage.Anchor = ((AnchorStyles)((((AnchorStyles.Top | AnchorStyles.Bottom)
+                richTextBoxMessage.Anchor = (((AnchorStyles.Top | AnchorStyles.Bottom)
                 | AnchorStyles.Left)
-                | AnchorStyles.Right)));
-                this.richTextBoxMessage.BorderStyle = BorderStyle.None;
-                this.richTextBoxMessage.DataBindings.Add(new Binding("Text", this.FlexibleMessageBoxFormBindingSource, "MessageText", true, DataSourceUpdateMode.OnPropertyChanged));
-                this.richTextBoxMessage.Font = new Font(Theme.Font.FontFamily, 9);
-                this.richTextBoxMessage.Location = new Point(50, 26);
-                this.richTextBoxMessage.Margin = new Padding(0);
-                this.richTextBoxMessage.Name = "richTextBoxMessage";
-                this.richTextBoxMessage.ReadOnly = true;
-                this.richTextBoxMessage.ScrollBars = RichTextBoxScrollBars.Vertical;
-                this.richTextBoxMessage.Size = new Size(200, 20);
-                this.richTextBoxMessage.TabIndex = 0;
-                this.richTextBoxMessage.TabStop = false;
-                this.richTextBoxMessage.Text = "<Message>";
-                this.richTextBoxMessage.LinkClicked += new LinkClickedEventHandler(this.LinkClicked);
+                | AnchorStyles.Right);
+                richTextBoxMessage.BorderStyle = BorderStyle.None;
+                richTextBoxMessage.DataBindings.Add(new Binding("Text", FlexibleMessageBoxFormBindingSource, "MessageText", true, DataSourceUpdateMode.OnPropertyChanged));
+                richTextBoxMessage.Font = new Font(Theme.Font.FontFamily, 9);
+                richTextBoxMessage.Location = new Point(50, 26);
+                richTextBoxMessage.Margin = new Padding(0);
+                richTextBoxMessage.Name = "richTextBoxMessage";
+                richTextBoxMessage.ReadOnly = true;
+                richTextBoxMessage.ScrollBars = RichTextBoxScrollBars.Vertical;
+                richTextBoxMessage.Size = new Size(200, 20);
+                richTextBoxMessage.TabIndex = 0;
+                richTextBoxMessage.TabStop = false;
+                richTextBoxMessage.Text = "<Message>";
+                richTextBoxMessage.LinkClicked += new LinkClickedEventHandler(LinkClicked);
                 // 
                 // panel1
                 // 
-                this.panel1.Anchor = ((AnchorStyles)((((AnchorStyles.Top | AnchorStyles.Bottom)
+                panel1.Anchor = (((AnchorStyles.Top | AnchorStyles.Bottom)
                 | AnchorStyles.Left)
-                | AnchorStyles.Right)));
-                this.panel1.Controls.Add(this.pictureBoxForIcon);
-                this.panel1.Controls.Add(this.richTextBoxMessage);
-                this.panel1.Location = new Point(-3, -4);
-                this.panel1.Name = "panel1";
-                this.panel1.Size = new Size(268, 59);
-                this.panel1.TabIndex = 1;
+                | AnchorStyles.Right);
+                panel1.Controls.Add(pictureBoxForIcon);
+                panel1.Controls.Add(richTextBoxMessage);
+                panel1.Location = new Point(-3, -4);
+                panel1.Name = "panel1";
+                panel1.Size = new Size(268, 59);
+                panel1.TabIndex = 1;
                 // 
                 // pictureBoxForIcon
                 // 
-                this.pictureBoxForIcon.BackColor = Color.Transparent;
-                this.pictureBoxForIcon.Location = new Point(15, 19);
-                this.pictureBoxForIcon.Name = "pictureBoxForIcon";
-                this.pictureBoxForIcon.Size = new Size(32, 32);
-                this.pictureBoxForIcon.TabIndex = 8;
-                this.pictureBoxForIcon.TabStop = false;
+                pictureBoxForIcon.BackColor = Color.Transparent;
+                pictureBoxForIcon.Location = new Point(15, 19);
+                pictureBoxForIcon.Name = "pictureBoxForIcon";
+                pictureBoxForIcon.Size = new Size(32, 32);
+                pictureBoxForIcon.TabIndex = 8;
+                pictureBoxForIcon.TabStop = false;
                 // 
                 // button2
                 // 
-                this.button2.Anchor = ((AnchorStyles)((AnchorStyles.Bottom | AnchorStyles.Right)));
-                this.button2.DialogResult = DialogResult.OK;
-                this.button2.Location = new Point(92, 67);
-                this.button2.MinimumSize = new Size(0, 24);
-                this.button2.Name = "button2";
-                this.button2.Size = new Size(75, 24);
-                this.button2.TabIndex = 3;
-                this.button2.Text = "OK";
-                this.button2.UseVisualStyleBackColor = true;
-                this.button2.Visible = false;
+                button2.Anchor = (AnchorStyles.Bottom | AnchorStyles.Right);
+                button2.DialogResult = DialogResult.OK;
+                button2.Location = new Point(92, 67);
+                button2.MinimumSize = new Size(0, 24);
+                button2.Name = "button2";
+                button2.Size = new Size(75, 24);
+                button2.TabIndex = 3;
+                button2.Text = "OK";
+                button2.UseVisualStyleBackColor = true;
+                button2.Visible = false;
                 // 
                 // button3
                 // 
-                this.button3.Anchor = ((AnchorStyles)((AnchorStyles.Bottom | AnchorStyles.Right)));
-                this.button3.AutoSize = true;
-                this.button3.DialogResult = DialogResult.OK;
-                this.button3.Location = new Point(173, 67);
-                this.button3.MinimumSize = new Size(0, 24);
-                this.button3.Name = "button3";
-                this.button3.Size = new Size(75, 24);
-                this.button3.TabIndex = 0;
-                this.button3.Text = "OK";
-                this.button3.UseVisualStyleBackColor = true;
-                this.button3.Visible = false;
+                button3.Anchor = (AnchorStyles.Bottom | AnchorStyles.Right);
+                button3.AutoSize = true;
+                button3.DialogResult = DialogResult.OK;
+                button3.Location = new Point(173, 67);
+                button3.MinimumSize = new Size(0, 24);
+                button3.Name = "button3";
+                button3.Size = new Size(75, 24);
+                button3.TabIndex = 0;
+                button3.Text = "OK";
+                button3.UseVisualStyleBackColor = true;
+                button3.Visible = false;
                 // 
                 // FlexibleMessageBoxForm
                 // 
-                this.AutoScaleDimensions = new SizeF(6F, 13F);
-                this.AutoScaleMode = AutoScaleMode.Font;
-                this.ClientSize = new Size(260, 102);
-                this.Controls.Add(this.button3);
-                this.Controls.Add(this.button2);
-                this.Controls.Add(this.panel1);
-                this.Controls.Add(this.button1);
-                this.DataBindings.Add(new Binding("Text", this.FlexibleMessageBoxFormBindingSource, "CaptionText", true));
-                this.Icon = GBAMusicStudio.Properties.Resources.Icon;
-                this.MaximizeBox = false;
-                this.MinimizeBox = false;
-                this.MinimumSize = new Size(276, 140);
-                this.Name = "FlexibleMessageBoxForm";
-                this.SizeGripStyle = SizeGripStyle.Show;
-                this.StartPosition = FormStartPosition.CenterParent;
-                this.Text = "<Caption>";
-                this.Shown += new EventHandler(this.FlexibleMessageBoxForm_Shown);
-                ((ISupportInitialize)(this.FlexibleMessageBoxFormBindingSource)).EndInit();
-                this.panel1.ResumeLayout(false);
-                ((ISupportInitialize)(this.pictureBoxForIcon)).EndInit();
-                this.ResumeLayout(false);
-                this.PerformLayout();
+                AutoScaleDimensions = new SizeF(6F, 13F);
+                AutoScaleMode = AutoScaleMode.Font;
+                ClientSize = new Size(260, 102);
+                Controls.Add(button3);
+                Controls.Add(button2);
+                Controls.Add(panel1);
+                Controls.Add(button1);
+                DataBindings.Add(new Binding("Text", FlexibleMessageBoxFormBindingSource, "CaptionText", true));
+                MaximizeBox = false;
+                MinimizeBox = false;
+                MinimumSize = new Size(276, 140);
+                Name = "FlexibleMessageBoxForm";
+                SizeGripStyle = SizeGripStyle.Show;
+                StartPosition = FormStartPosition.CenterParent;
+                Text = "<Caption>";
+                Shown += new EventHandler(FlexibleMessageBoxForm_Shown);
+                ((ISupportInitialize)(FlexibleMessageBoxFormBindingSource)).EndInit();
+                panel1.ResumeLayout(false);
+                ((ISupportInitialize)(pictureBoxForIcon)).EndInit();
+                ResumeLayout(false);
+                PerformLayout();
             }
 
             ThemedButton button1, button2, button3;
@@ -338,8 +337,8 @@ namespace Kermalis.GBAMusicStudio.UI
                 //Try to evaluate the language. If this fails, the fallback language English will be used
                 Enum.TryParse(CultureInfo.CurrentUICulture.TwoLetterISOLanguageName, out languageID);
 
-                this.KeyPreview = true;
-                this.KeyUp += FlexibleMessageBoxForm_KeyUp;
+                KeyPreview = true;
+                KeyUp += FlexibleMessageBoxForm_KeyUp;
             }
 
             #endregion
@@ -348,7 +347,10 @@ namespace Kermalis.GBAMusicStudio.UI
 
             static string[] GetStringRows(string message)
             {
-                if (string.IsNullOrEmpty(message)) return null;
+                if (string.IsNullOrEmpty(message))
+                {
+                    return null;
+                }
 
                 var messageRows = message.Split(new char[] { '\n' }, StringSplitOptions.None);
                 return messageRows;
@@ -358,7 +360,7 @@ namespace Kermalis.GBAMusicStudio.UI
             {
                 var buttonTextArrayIndex = Convert.ToInt32(buttonID);
 
-                switch (this.languageID)
+                switch (languageID)
                 {
                     case TwoLetterISOLanguageID.de: return BUTTON_TEXTS_GERMAN_DE[buttonTextArrayIndex];
                     case TwoLetterISOLanguageID.es: return BUTTON_TEXTS_SPANISH_ES[buttonTextArrayIndex];
@@ -373,8 +375,15 @@ namespace Kermalis.GBAMusicStudio.UI
                 const double MIN_FACTOR = 0.2;
                 const double MAX_FACTOR = 1.0;
 
-                if (workingAreaFactor < MIN_FACTOR) return MIN_FACTOR;
-                if (workingAreaFactor > MAX_FACTOR) return MAX_FACTOR;
+                if (workingAreaFactor < MIN_FACTOR)
+                {
+                    return MIN_FACTOR;
+                }
+
+                if (workingAreaFactor > MAX_FACTOR)
+                {
+                    return MAX_FACTOR;
+                }
 
                 return workingAreaFactor;
             }
@@ -399,7 +408,10 @@ namespace Kermalis.GBAMusicStudio.UI
 
                 //Get rows. Exit if there are no rows to render...
                 var stringRows = GetStringRows(text);
-                if (stringRows == null) return;
+                if (stringRows == null)
+                {
+                    return;
+                }
 
                 //Calculate whole text height
                 var textHeight = TextRenderer.MeasureText(text, FONT).Height;
@@ -552,7 +564,7 @@ namespace Kermalis.GBAMusicStudio.UI
                 Button buttonToFocus;
 
                 //Set the default button...
-                switch (this.defaultButton)
+                switch (defaultButton)
                 {
                     case MessageBoxDefaultButton.Button1:
                     default:
@@ -566,19 +578,22 @@ namespace Kermalis.GBAMusicStudio.UI
                         break;
                 }
 
-                if (buttonIndexToFocus > this.visibleButtonsCount) buttonIndexToFocus = this.visibleButtonsCount;
+                if (buttonIndexToFocus > visibleButtonsCount)
+                {
+                    buttonIndexToFocus = visibleButtonsCount;
+                }
 
                 if (buttonIndexToFocus == 3)
                 {
-                    buttonToFocus = this.button3;
+                    buttonToFocus = button3;
                 }
                 else if (buttonIndexToFocus == 2)
                 {
-                    buttonToFocus = this.button2;
+                    buttonToFocus = button2;
                 }
                 else
                 {
-                    buttonToFocus = this.button1;
+                    buttonToFocus = button1;
                 }
 
                 buttonToFocus.Focus();
@@ -607,15 +622,15 @@ namespace Kermalis.GBAMusicStudio.UI
                 //Handle standard key strikes for clipboard copy: "Ctrl + C" and "Ctrl + Insert"
                 if (e.Control && (e.KeyCode == Keys.C || e.KeyCode == Keys.Insert))
                 {
-                    var buttonsTextLine = (this.button1.Visible ? this.button1.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty)
-                                        + (this.button2.Visible ? this.button2.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty)
-                                        + (this.button3.Visible ? this.button3.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty);
+                    var buttonsTextLine = (button1.Visible ? button1.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty)
+                                        + (button2.Visible ? button2.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty)
+                                        + (button3.Visible ? button3.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty);
 
                     //Build same clipboard text like the standard .Net MessageBox
                     var textForClipboard = STANDARD_MESSAGEBOX_SEPARATOR_LINES
-                                         + this.Text + Environment.NewLine
+                                         + Text + Environment.NewLine
                                          + STANDARD_MESSAGEBOX_SEPARATOR_LINES
-                                         + this.richTextBoxMessage.Text + Environment.NewLine
+                                         + richTextBoxMessage.Text + Environment.NewLine
                                          + STANDARD_MESSAGEBOX_SEPARATOR_LINES
                                          + buttonsTextLine.Replace("&", string.Empty) + Environment.NewLine
                                          + STANDARD_MESSAGEBOX_SEPARATOR_LINES;

--- a/GBAMusicStudio/UI/MainForm.cs
+++ b/GBAMusicStudio/UI/MainForm.cs
@@ -15,6 +15,8 @@ namespace Kermalis.GBAMusicStudio.UI
     [DesignerCategory("")]
     class MainForm : ThemedForm
     {
+        public static MainForm Instance { get; } = new MainForm();
+
         bool stopUI = false, drag = false;
         readonly List<sbyte> pianoNotes = new List<sbyte>();
         public readonly bool[] PianoTracks = new bool[16];
@@ -58,7 +60,7 @@ namespace Kermalis.GBAMusicStudio.UI
             }
             base.Dispose(disposing);
         }
-        public MainForm()
+        private MainForm()
         {
             components = new Container();
 
@@ -139,7 +141,7 @@ namespace Kermalis.GBAMusicStudio.UI
             // Volume bar & Position bar
             int sWidth = (int)(iWidth / sfWidth);
             int sX = iWidth - sWidth - 4;
-            positionBar = new ColorSlider()
+            positionBar = new ColorSlider
             {
                 Anchor = AnchorStyles.Top | AnchorStyles.Right,
                 Enabled = false,
@@ -149,19 +151,19 @@ namespace Kermalis.GBAMusicStudio.UI
             };
             positionBar.MouseUp += SetSongPosition;
             positionBar.MouseDown += (o, e) => drag = true;
-            volumeBar = new ColorSlider()
+            volumeBar = new ColorSlider
             {
+                Enabled = false,
                 LargeChange = 20,
                 Location = new Point(83, 45),
                 Maximum = 100,
                 Size = new Size(155, 27),
                 SmallChange = 5
             };
-            volumeBar.ValueChanged += (o, e) => SoundMixer.Instance.MasterVolume = volumeBar.Value / (float)volumeBar.Maximum;
-            volumeBar.Value = Config.Instance.Volume; // Update SoundMixer volume
+            volumeBar.ValueChanged += VolumeBar_ValueChanged;
 
             // Playlist box
-            songsComboBox = new ImageComboBox()
+            songsComboBox = new ImageComboBox
             {
                 Anchor = AnchorStyles.Top | AnchorStyles.Right,
                 Enabled = false,
@@ -171,14 +173,14 @@ namespace Kermalis.GBAMusicStudio.UI
             songsComboBox.SelectedIndexChanged += SongsComboBox_SelectedIndexChanged;
 
             // Track info
-            trackInfo = new TrackInfoControl()
+            trackInfo = new TrackInfoControl
             {
                 Dock = DockStyle.Fill,
                 Size = new Size(iWidth, 690)
             };
 
             // Split container
-            splitContainer = new SplitContainer()
+            splitContainer = new SplitContainer
             {
                 BackColor = Theme.TitleBar,
                 Dock = DockStyle.Fill,
@@ -217,6 +219,17 @@ namespace Kermalis.GBAMusicStudio.UI
             }
         }
 
+        void VolumeBar_ValueChanged(object sender, EventArgs e)
+        {
+            SoundMixer.Instance.SetVolume(volumeBar.Value / (float)volumeBar.Maximum);
+        }
+        public void SetVolumeBarValue(float volume)
+        {
+            volumeBar.ValueChanged -= VolumeBar_ValueChanged;
+            volumeBar.Value = (int)(volume * volumeBar.Maximum);
+            volumeBar.ValueChanged += VolumeBar_ValueChanged;
+        }
+
         void SetSongPosition(object sender, EventArgs e)
         {
             SongPlayer.Instance.SetSongPosition(positionBar.Value);
@@ -243,7 +256,7 @@ namespace Kermalis.GBAMusicStudio.UI
             songsComboBox.SelectedIndexChanged -= SongsComboBox_SelectedIndexChanged;
 
             APlaylist mainPlaylist = ROM.Instance.Game.Playlists[0];
-            List<ASong> songs = mainPlaylist.Songs.ToList();
+            var songs = mainPlaylist.Songs.ToList();
             ASong song = songs.SingleOrDefault(s => s.Index == songNumerical.Value);
             if (song != null)
             {
@@ -504,7 +517,7 @@ namespace Kermalis.GBAMusicStudio.UI
 
             openMIDIToolStripMenuItem.Enabled =
                 teToolStripMenuItem.Enabled = vteToolStripMenuItem.Enabled = eSf2ToolStripMenuItem.Enabled = eASMToolStripMenuItem.Enabled = eMIDIToolStripMenuItem.Enabled =
-                songsComboBox.Enabled = songNumerical.Enabled = playButton.Enabled = true;
+                songsComboBox.Enabled = songNumerical.Enabled = playButton.Enabled = volumeBar.Enabled = true;
 
             openASMToolStripMenuItem.Enabled = ROM.Instance.Game.Engine.Type == EngineType.M4A;
 

--- a/GBAMusicStudio/UI/MidiConverterDialog.cs
+++ b/GBAMusicStudio/UI/MidiConverterDialog.cs
@@ -50,7 +50,7 @@ namespace Kermalis.GBAMusicStudio.UI
 
         void PreviewSong(object sender, EventArgs e)
         {
-            ((MainForm)Owner).PreviewSong(song, Path.GetFileName(midiFileName));
+            MainForm.Instance.PreviewSong(song, Path.GetFileName(midiFileName));
         }
         void OpenMIDI(object sender, EventArgs e)
         {

--- a/GBAMusicStudio/UI/TrackInfoControl.cs
+++ b/GBAMusicStudio/UI/TrackInfoControl.cs
@@ -98,7 +98,7 @@ namespace Kermalis.GBAMusicStudio.UI
                 {
                     if (pianos[i] == check)
                     {
-                        ((MainForm)ParentForm).PianoTracks[i] = pianos[i].Checked && pianos[i].Visible;
+                        MainForm.Instance.PianoTracks[i] = pianos[i].Checked && pianos[i].Visible;
                     }
                     if (pianos[i].Checked)
                     {


### PR DESCRIPTION
This changes the IEEE float audio stream to an 8-bit audio stream

Done:
* Removed config sample rate and updated to the GBA's refresh rate which allows each game to sound like its intended engine frequency
* Bound volume slider to Windows mixer for the application, which greatly improves audio quality at low volumes and makes volume changes instant

TODO:
* Change fade out and fade in to use the new volume control
* Stop popping
* Bring back reverb
* Bring back voice table saver
* Update ProcessSquare, ProcessSaw, and ProcessTri to use bytes in their calculation instead of floats