### PR TITLE
Added support for Fire Emblem 8 (USA)

### DIFF
--- a/VG Music Studio/MP2K.yaml
+++ b/VG Music Studio/MP2K.yaml
@@ -646,6 +646,17 @@ B24P_00:
   Name: "Pokémon Mystery Dungeon: Red Rescue Team (Europe)"
   SongTableOffsets: 0x1E866BC
   Copy: "B24E_00"
+BE8E_00:
+  Name: "Fire Emblem: The Sacred Stones (USA)"
+  Creator: "Intelligent Systems"
+  SongTable: 0x224470
+  SongTableSize: 1000
+  SampleRate: 3
+  ReverbType: "Normal"
+  Reverb: 0
+  Volume: 15
+  HasGoldenSunSynths: False
+  HasPokemonCompression: False
 BMXE_00:
   Name: "Metroid: Zero Mission (USA)"
   SongTableOffsets: 0x8F2C0


### PR DESCRIPTION
Fire Emblem: The Binding Blade (JP), Fire Emblem 7 (JP), and Fire Emblem 8 (JP) all have documentation on their song table locations and lengths as well, there also exist European versions of Fire Emblem 7 and 8 with little to no documentation; all 5 of them use MP2K the same as the 2 now present in this file.