### PR TITLE
Fixed endless loop if track is stopped at the end

### DIFF
--- a/VG Music Studio/Core/NDS/SDAT/Player.cs
+++ b/VG Music Studio/Core/NDS/SDAT/Player.cs
@@ -1655,7 +1655,7 @@ namespace Kermalis.VGMusicStudio.Core.NDS.SDAT
                             {
                                 if (ElapsedTicks == MaxTicks)
                                 {
-                                    if (!track.Stopped)
+                                    if (track.Stopped)
                                     {
                                         List<long> t = Events[i][track.CurEvent].Ticks;
                                         ElapsedTicks = t.Count == 0 ? 0 : t[0] - track.Rest; // Prevent crashes with songs that don't load all ticks yet (See SetTicks())


### PR DESCRIPTION
Before, if a track was finished and stopped at the end, it would be forever in the loop.