### PR TITLE
Add new entries and differences between versions of the MLSS engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,20 @@ Discord Server: https://discord.gg/mBQXCTs
 ## Mario & Luigi: Superstar Saga Engine
 * ADSR
 * Voice table - Find out the last 4 bytes in voice entry struct (probably ADSR)
+* PSG channels 3 and 4
+* Some more unknown commands
+* Optimize playback
+* Rename to Alphadream Engine
 
 ## SDAT Engine
 * Find proper formulas for LFO
+* Optimize playback
 
 ## DSE Engine
 * ADSR
 * Pitch bend
 * Ability to load SMDB and SWDB (Big Endian as opposed to SMDL and SWDL for Little Endian)
+* Some more unknown commands
 
 ----
 # Special Thanks To:

--- a/VG Music Studio/Core/GBA/MLSS/Config.cs
+++ b/VG Music Studio/Core/GBA/MLSS/Config.cs
@@ -17,6 +17,7 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
         public byte Version;
 
         public string Name;
+        public int SoundEngineVersion; //Version of the sound engine used by the game
         public int[] SongTableOffsets;
         public long[] SongTableSizes;
         public int VoiceTableOffset;
@@ -51,6 +52,7 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                     }
 
                     YamlNode nameNode = null,
+                        soundEngineVersionNode = null,
                         songTableOffsetsNode = null,
                         voiceTableOffsetNode = null,
                         sampleTableOffsetNode = null,
@@ -74,6 +76,10 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                         if (gameToLoad.Children.TryGetValue(nameof(Name), out node))
                         {
                             nameNode = node;
+                        }
+                        if (gameToLoad.Children.TryGetValue(nameof(SoundEngineVersion), out node))
+                        {
+                            soundEngineVersionNode = node;
                         }
                         if (gameToLoad.Children.TryGetValue(nameof(SongTableOffsets), out node))
                         {
@@ -150,6 +156,11 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                         SongTableOffsets[i] = (int)Util.Utils.ParseValue(nameof(SongTableOffsets), songTables[i], 0, maxOffset);
                         SongTableSizes[i] = Util.Utils.ParseValue(nameof(SongTableSizes), songTableSizes[i], 1, maxOffset);
                     }
+                    if (soundEngineVersionNode == null)
+                    {
+                        throw new BetterKeyNotFoundException(nameof(SoundEngineVersion), null);
+                    }
+                    SoundEngineVersion = (int)Util.Utils.ParseValue(nameof(SoundEngineVersion), soundEngineVersionNode.ToString(), 0, maxOffset);
                     if (voiceTableOffsetNode == null)
                     {
                         throw new BetterKeyNotFoundException(nameof(VoiceTableOffset), null);

--- a/VG Music Studio/Core/GBA/MLSS/Config.cs
+++ b/VG Music Studio/Core/GBA/MLSS/Config.cs
@@ -17,7 +17,7 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
         public byte Version;
 
         public string Name;
-        public int SoundEngineVersion; //Version of the sound engine used by the game
+        public AudioEngineVersion AudioEngineVersion;
         public int[] SongTableOffsets;
         public long[] SongTableSizes;
         public int VoiceTableOffset;
@@ -52,7 +52,7 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                     }
 
                     YamlNode nameNode = null,
-                        soundEngineVersionNode = null,
+                        audioEngineVersionNode = null,
                         songTableOffsetsNode = null,
                         voiceTableOffsetNode = null,
                         sampleTableOffsetNode = null,
@@ -77,9 +77,9 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                         {
                             nameNode = node;
                         }
-                        if (gameToLoad.Children.TryGetValue(nameof(SoundEngineVersion), out node))
+                        if (gameToLoad.Children.TryGetValue(nameof(AudioEngineVersion), out node))
                         {
-                            soundEngineVersionNode = node;
+                            audioEngineVersionNode = node;
                         }
                         if (gameToLoad.Children.TryGetValue(nameof(SongTableOffsets), out node))
                         {
@@ -129,6 +129,11 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                         throw new BetterKeyNotFoundException(nameof(Name), null);
                     }
                     Name = nameNode.ToString();
+                    if (audioEngineVersionNode == null)
+                    {
+                        throw new BetterKeyNotFoundException(nameof(AudioEngineVersion), null);
+                    }
+                    AudioEngineVersion = Util.Utils.ParseEnum<AudioEngineVersion>(nameof(AudioEngineVersion), audioEngineVersionNode.ToString());
                     if (songTableOffsetsNode == null)
                     {
                         throw new BetterKeyNotFoundException(nameof(SongTableOffsets), null);
@@ -156,11 +161,6 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                         SongTableOffsets[i] = (int)Util.Utils.ParseValue(nameof(SongTableOffsets), songTables[i], 0, maxOffset);
                         SongTableSizes[i] = Util.Utils.ParseValue(nameof(SongTableSizes), songTableSizes[i], 1, maxOffset);
                     }
-                    if (soundEngineVersionNode == null)
-                    {
-                        throw new BetterKeyNotFoundException(nameof(SoundEngineVersion), null);
-                    }
-                    SoundEngineVersion = (int)Util.Utils.ParseValue(nameof(SoundEngineVersion), soundEngineVersionNode.ToString(), 0, maxOffset);
                     if (voiceTableOffsetNode == null)
                     {
                         throw new BetterKeyNotFoundException(nameof(VoiceTableOffset), null);

--- a/VG Music Studio/Core/GBA/MLSS/Enums.cs
+++ b/VG Music Studio/Core/GBA/MLSS/Enums.cs
@@ -1,5 +1,11 @@
 ﻿namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
 {
+    internal enum AudioEngineVersion
+    {
+        MLSS,
+        Hamtaro
+    }
+
     internal enum EnvelopeState
     {
         Attack,

--- a/VG Music Studio/Core/GBA/MLSS/Player.cs
+++ b/VG Music Studio/Core/GBA/MLSS/Player.cs
@@ -139,12 +139,6 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                             bool cont = true;
                             while (cont)
                             {
-                                int version = config.SoundEngineVersion; //Version of the engine used
-                                /*
-                                 * Version 2 adds 1 byte for the volume after every note event 
-                                 * while in version 1 the 0xF1 command is used to set the volume.
-                                 * I don't think there is any other difference besides that.
-                                 **/
                                 long offset = config.Reader.BaseStream.Position;
                                 void AddEvent(ICommand command)
                                 {
@@ -156,25 +150,29 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                                     case 0x00:
                                     {
                                         byte keyArg = config.Reader.ReadByte();
-                                        if (version==1) // Mario & Luigi
+                                        switch (config.AudioEngineVersion)
                                         {
-                                            byte duration = config.Reader.ReadByte();
-                                            if (!EventExists(offset))
+                                            case AudioEngineVersion.MLSS:
                                             {
-                                                AddEvent(new FreeNoteCommand { Key = (byte)(keyArg - 0x80), Duration = duration });
+                                                byte duration = config.Reader.ReadByte();
+                                                if (!EventExists(offset))
+                                                {
+                                                    AddEvent(new FreeNoteCommand { Key = (byte)(keyArg - 0x80), Duration = duration });
+                                                }
+                                                break;
+                                            }
+                                            case AudioEngineVersion.Hamtaro:
+                                            {
+                                                byte volume = config.Reader.ReadByte();
+                                                byte duration = config.Reader.ReadByte();
+                                                if (!EventExists(offset))
+                                                {
+                                                    AddEvent(new VolumeCommand { Volume = volume });
+                                                    AddEvent(new FreeNoteCommand { Key = (byte)(keyArg - 0x80), Duration = duration });
+                                                }
+                                                break;
                                             }
                                         }
-                                        if (version==2) // Hamtaro
-                                        {
-                                            byte volume = config.Reader.ReadByte();
-                                            byte duration = config.Reader.ReadByte();
-                                            if (!EventExists(offset))
-                                            {
-                                                AddEvent(new VolumeCommand { Volume = volume });
-                                                AddEvent(new FreeNoteCommand { Key = (byte)(keyArg - 0x80), Duration = duration });
-                                            }
-                                        }
-                                        
                                         break;
                                     }
                                     case 0xF0:
@@ -269,21 +267,25 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                                         if (cmd <= 0xEF)
                                         {
                                             byte key = config.Reader.ReadByte();
-                                             
-                                            if (version == 1) // Mario & Luigi
+                                            switch (config.AudioEngineVersion)
                                             {
-                                                if (!EventExists(offset))
+                                                case AudioEngineVersion.MLSS:
                                                 {
-                                                    AddEvent(new NoteCommand { Key = key, Duration = cmd });
+                                                    if (!EventExists(offset))
+                                                    {
+                                                        AddEvent(new NoteCommand { Key = key, Duration = cmd });
+                                                    }
+                                                    break;
                                                 }
-                                            }
-                                            else if (version == 2) // Hamtaro
-                                            {
-                                                byte volume = config.Reader.ReadByte();
-                                                if (!EventExists(offset))
+                                                case AudioEngineVersion.Hamtaro:
                                                 {
-                                                    AddEvent(new VolumeCommand { Volume = volume });
-                                                    AddEvent(new NoteCommand { Key = key, Duration = cmd });
+                                                    byte volume = config.Reader.ReadByte();
+                                                    if (!EventExists(offset))
+                                                    {
+                                                        AddEvent(new VolumeCommand { Volume = volume });
+                                                        AddEvent(new NoteCommand { Key = key, Duration = cmd });
+                                                    }
+                                                    break;
                                                 }
                                             }
                                         }
@@ -444,39 +446,47 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
             }
         }
 
+        private VoiceEntry GetVoiceEntry(byte voice, byte key)
+        {
+            int vto = config.VoiceTableOffset;
+            short voiceOffset = config.Reader.ReadInt16(vto + (voice * 2));
+            short nextVoiceOffset = config.Reader.ReadInt16(vto + ((voice + 1) * 2));
+            if (voiceOffset == nextVoiceOffset)
+            {
+                return null;
+            }
+            else
+            {
+                long pos = vto + voiceOffset; // Prevent object creation in the last iteration
+                VoiceEntry e = config.Reader.ReadObject<VoiceEntry>(pos);
+                while (e.MinKey > key || e.MaxKey < key)
+                {
+                    pos += 8;
+                    if (pos == nextVoiceOffset)
+                    {
+                        return null;
+                    }
+                    e = config.Reader.ReadObject<VoiceEntry>();
+                }
+                return e;
+            }
+        }
         private void PlayNote(Track track, byte key, byte duration)
         {
-            short voiceOffset = config.Reader.ReadInt16(config.VoiceTableOffset + (track.Voice * 2));
-            short nextVoiceOffset = config.Reader.ReadInt16(config.VoiceTableOffset + ((track.Voice + 1) * 2));
-            int numEntries = (nextVoiceOffset - voiceOffset) / 8; // Each entry is 8 bytes
-            VoiceEntry entry = null;
-            config.Reader.BaseStream.Position = config.VoiceTableOffset + voiceOffset;
-            for (int i = 0; i < numEntries; i++)
-            {
-                VoiceEntry e = config.Reader.ReadObject<VoiceEntry>();
-                if (e.MinKey <= key && e.MaxKey >= key)
-                {
-                    entry = e;
-                    break;
-                }
-            }
+            VoiceEntry entry = GetVoiceEntry(track.Voice, key);
             if (entry != null)
             {
                 track.NoteDuration = duration;
                 if (track.Index >= 8)
                 {
                     // TODO: "Sample" byte in VoiceEntry
-                    // TODO: Check if this check is necessary; edit: this check crashes the application in the 2nd version
-                    /*
-                    if (track.Voice >= 190 && track.Voice < 200)
-                    {*/
                     ((SquareChannel)track.Channel).Init(key, new ADSR { A = 0xFF, D = 0x00, S = 0xFF, R = 0x00 }, track.Volume, track.Panpot, track.GetPitch());
-                    //}
                 }
                 else
                 {
-                    int sampleOffset = config.Reader.ReadInt32(config.SampleTableOffset + (entry.Sample * 4)); // Some entries are 0. If you play them, are they silent, or does it not care if they are 0?
-                    ((PCMChannel)track.Channel).Init(key, new ADSR { A = 0xFF, D = 0x00, S = 0xFF, R = 0x00 }, config.SampleTableOffset + sampleOffset, entry.IsFixedFrequency == 0x80);
+                    int sto = config.SampleTableOffset;
+                    int sampleOffset = config.Reader.ReadInt32(sto + (entry.Sample * 4)); // Some entries are 0. If you play them, are they silent, or does it not care if they are 0?
+                    ((PCMChannel)track.Channel).Init(key, new ADSR { A = 0xFF, D = 0x00, S = 0xFF, R = 0x00 }, sto + sampleOffset, entry.IsFixedFrequency == 0x80);
                     track.Channel.SetVolume(track.Volume, track.Panpot);
                     track.Channel.SetPitch(track.GetPitch());
                 }

--- a/VG Music Studio/Core/GBA/MLSS/Player.cs
+++ b/VG Music Studio/Core/GBA/MLSS/Player.cs
@@ -466,11 +466,12 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MLSS
                 if (track.Index >= 8)
                 {
                     // TODO: "Sample" byte in VoiceEntry
-                    // TODO: Check if this check is necessary
+                    // TODO: Check if this check is necessary; edit: this check crashes the application in the 2nd version
+                    /*
                     if (track.Voice >= 190 && track.Voice < 200)
-                    {
-                        ((SquareChannel)track.Channel).Init(key, new ADSR { A = 0xFF, D = 0x00, S = 0xFF, R = 0x00 }, track.Volume, track.Panpot, track.GetPitch());
-                    }
+                    {*/
+                    ((SquareChannel)track.Channel).Init(key, new ADSR { A = 0xFF, D = 0x00, S = 0xFF, R = 0x00 }, track.Volume, track.Panpot, track.GetPitch());
+                    //}
                 }
                 else
                 {

--- a/VG Music Studio/Core/GBA/MLSS/Track.cs
+++ b/VG Music Studio/Core/GBA/MLSS/Track.cs
@@ -20,13 +20,18 @@
         public Track(byte i, Mixer mixer)
         {
             Index = i;
+            // TODO: PSG Channels 3 and 4 are also usable
             Type = i >= 8 ? i % 2 == 0 ? "Square 1" : "Square 2" : "PCM8";
             Channel = i >= 8 ? (Channel)new SquareChannel(mixer) : new PCMChannel(mixer);
         }
         public void Init()
         {
-            Voice = Rest = BendRange = NoteDuration = 0;
-            PitchBend = Panpot = 0;
+            Voice = 0;
+            Rest = 0;
+            BendRange = 2;
+            NoteDuration = 0;
+            PitchBend = 0;
+            Panpot = 0;
             CurEvent = 0;
             Stopped = false;
             Volume = 0x7F;

--- a/VG Music Studio/MLSS.yaml
+++ b/VG Music Studio/MLSS.yaml
@@ -1,5 +1,6 @@
 A88E_00:
   Name: "Mario & Luigi - Superstar Saga (USA)"
+  SoundEngineVersion: 1
   SongTableOffsets: 0x21CB70
   SongTableSizes: 407
   VoiceTableOffset: 0x21D1CC
@@ -60,6 +61,7 @@ A88E_00:
       50: "Bean Time!"
 A88J_00:
   Name: "Mario & Luigi - Superstar Saga (Japan)"
+  SoundEngineVersion: 1
   SongTableOffsets: 0x205060
   SongTableSizes: 418
   VoiceTableOffset: 0x2056E8
@@ -68,7 +70,138 @@ A88J_00:
   Copy: "A88E_00"
 A88P_00:
   Name: "Mario & Luigi - Superstar Saga (Europe)"
+  SoundEngineVersion: 1
   SongTableOffsets: 0x21DC50
   VoiceTableOffset: 0x21E2AC
   SampleTableOffset: 0xA82088
   Copy: "A88E_00"
+A84P_00:
+  Name: "Hamtaro - Rainbow Rescue (Europe)"
+  SoundEngineVersion: 2
+  SongTableOffsets: 0x694300
+  SongTableSizes: 150
+  VoiceTableOffset: 0x694558
+  SampleTableOffset: 0xBCD510
+  SampleTableSize: 149
+  Remap: "MLSS"
+  Playlists:
+    Music:
+      1: "Title"
+      2: "Menu"
+      3: "Stickers"
+      4: "Coloring"
+      5: "The Clubhouse"
+      6: "Ham-Ham Lawn"
+      7: "Final Credits"
+      8: "Bo"
+      9: "Sunny Peak"
+      10: "Flower Ranch"
+      11: "Clover Elementary"
+      12: "Ticky-Ticky Park"
+      13: "Tip-Top Fair"
+      14: "Taiko Drumming"
+      15: "Sparkle Coast"
+      16: "Aquarium"
+      17: "Hamstarr Manor"
+      18: "Puntaros"
+      19: "Acorn Trail / Sea Spray Park"
+      20: "Rainbow Theater"
+      21: "Ham Game #1"
+      22: "Ham Game #2"
+      23: "Ham Game #3"
+      24: "Ham Game #4"
+      25: "Credits"
+      26: "Ham-Ham Lawn (again)"
+      27: "Ham-Ham March"
+      28: "That's Not Good..."
+      29: "Uh-Oh..."
+      30: "Success!"
+      31: "Oh No!"
+      32: "Headband-Ham"
+      33: "Bittersweet"
+      34: "We did it!"
+      35: "Pigeon Ride"
+      36: "Boss"
+      37: "Hamstarr"
+      38: "Jingle"
+      39: "Carrobo"
+A84J_00:
+  Name: "Hamtaro - Rainbow Rescue (Japan)"
+  SoundEngineVersion: 2
+  SongTableOffsets: 0x4DDE20
+  VoiceTableOffset: 0x4DE078
+  SampleTableOffset: 0x742FFC
+  Copy: "A84P_00"
+B85A_00:
+  Name: "Hamtaro - Ham-Ham Games (Japan/USA)"
+  SoundEngineVersion: 2
+  SongTableOffsets: 0xDED20
+  SongTableSizes: 212
+  VoiceTableOffset: 0xDF10C
+  SampleTableOffset: 0x100000
+  SampleTableSize: 368
+  Remap: "MLSS"
+  Playlists:
+    Music:
+      1: "Title"
+      2: "Menu"
+      3: "The Clubhouse"
+      4: "Cards / Crystal"
+      5: "Introduction"
+      6: "Credits"
+      7: "Hamigo"
+      8: "Event Preparation / Results"
+      9: "Synchronized Swimming"
+      10: "Other Events"
+      11: "Marathon #1"
+      12: "Marathon #2"
+      13: "Marathon #3"
+      14: "Marathon #4"
+      15: "Marathon #5"
+      16: "Results Ceremony"
+      17: "Ham Shopping Network"
+      18: "Ham Studio News"
+      19: "Ham Fortune Telling"
+      20: "Ham Studio Shows Introduction"
+      21: "BGM #1"
+      22: "BGM #2"
+      23: "BGM #3"
+      24: "BGM #4"
+      25: "BGM #5"
+      26: "BGM #6"
+      27: "BGM #7"
+      28: "BGM #8"
+      29: "BGM #9"
+      30: "BGM #10"
+      31: "BGM #11"
+      32: "Stadium Events"
+      33: "BGM #12"
+      34: "BGM #13"
+      35: "BGM #14"
+      36: "BGM #15"
+      37: "BGM #16"
+      38: "BGM #17"
+      39: "BGM #18"
+      40: "BGM #19"
+      41: "BGM #20"
+      42: "???"
+      43: "BGM #21"
+      44: "BGM #22"
+      45: "BGM #23"
+      46: "BGM #24"
+      47: "BGM #25"
+      48: "BGM #26"
+      49: "BGM #27"
+      50: "BGM #28"
+      51: "BGM #29"
+      52: "BGM #30"
+      53: "Minigame A"
+      54: "Minigame B"
+      55: "Carrobo"
+B85P_00:
+  Name: "Hamtaro - Ham-Ham Games (Europe)"
+  SoundEngineVersion: 2
+  SongTableOffsets: 0xDED20
+  VoiceTableOffset: 0xDF10C
+  SampleTableOffset: 0x100000
+  Copy: "B85A_00"

--- a/VG Music Studio/MLSS.yaml
+++ b/VG Music Studio/MLSS.yaml
@@ -1,6 +1,6 @@
 A88E_00:
   Name: "Mario & Luigi - Superstar Saga (USA)"
-  SoundEngineVersion: 1
+  AudioEngineVersion: "MLSS"
   SongTableOffsets: 0x21CB70
   SongTableSizes: 407
   VoiceTableOffset: 0x21D1CC
@@ -61,7 +61,6 @@ A88E_00:
       50: "Bean Time!"
 A88J_00:
   Name: "Mario & Luigi - Superstar Saga (Japan)"
-  SoundEngineVersion: 1
   SongTableOffsets: 0x205060
   SongTableSizes: 418
   VoiceTableOffset: 0x2056E8
@@ -70,14 +69,13 @@ A88J_00:
   Copy: "A88E_00"
 A88P_00:
   Name: "Mario & Luigi - Superstar Saga (Europe)"
-  SoundEngineVersion: 1
   SongTableOffsets: 0x21DC50
   VoiceTableOffset: 0x21E2AC
   SampleTableOffset: 0xA82088
   Copy: "A88E_00"
 A84P_00:
   Name: "Hamtaro - Rainbow Rescue (Europe)"
-  SoundEngineVersion: 2
+  AudioEngineVersion: "Hamtaro"
   SongTableOffsets: 0x694300
   SongTableSizes: 150
   VoiceTableOffset: 0x694558
@@ -127,14 +125,13 @@ A84P_00:
       39: "Carrobo"
 A84J_00:
   Name: "Hamtaro - Rainbow Rescue (Japan)"
-  SoundEngineVersion: 2
   SongTableOffsets: 0x4DDE20
   VoiceTableOffset: 0x4DE078
   SampleTableOffset: 0x742FFC
   Copy: "A84P_00"
 B85A_00:
   Name: "Hamtaro - Ham-Ham Games (Japan/USA)"
-  SoundEngineVersion: 2
+  AudioEngineVersion: "Hamtaro"
   SongTableOffsets: 0xDED20
   SongTableSizes: 212
   VoiceTableOffset: 0xDF10C
@@ -200,7 +197,6 @@ B85A_00:
       55: "Carrobo"
 B85P_00:
   Name: "Hamtaro - Ham-Ham Games (Europe)"
-  SoundEngineVersion: 2
   SongTableOffsets: 0xDED20
   VoiceTableOffset: 0xDF10C
   SampleTableOffset: 0x100000

--- a/VG Music Studio/MP2K.yaml
+++ b/VG Music Studio/MP2K.yaml
@@ -94,6 +94,23 @@ A7KP_00:
   Name: "Kirby: Nightmare in Dream Land (Europe)"
   SongTableOffsets: 0x843B50
   Copy: "A7KE_00"
+A88E_00:
+  Name: "Mario & Luigi - Superstar Saga (USA)"
+  SongTableOffsets: 0xFB5DA4
+  SongTableSizes: 323
+  SampleRate: 2
+  ReverbType: "Normal"
+  Reverb: 0
+  Volume: 15
+  HasGoldenSunSynths: False
+  HasPokemonCompression: False
+A88J_00:
+  Name: "Mario & Luigi - Superstar Saga (Japan)"
+  SongTableOffsets: 0xFB5E00
+  Copy: "A88E_00"
+A88P_00:
+  Name: "Mario & Luigi - Superstar Saga (Europe)"
+  Copy: "A88E_00"
 AE7E_00:
   Name: "Fire Emblem: The Blazing Blade (USA)"
   SongTableOffsets: 0x69D6D8


### PR DESCRIPTION
Mario & Luigi and the GBA Hamtaro games from AlphaDream use a nearly identical sound engine.
The only difference I found so far is that the volume is differently set.
Also, ADSR doesn't work properly in the 2nd version.