### PR TITLE
Better GBA samplerate?

### DIFF
--- a/VG Music Studio/Core/GBA/AlphaDream/Mixer.cs
+++ b/VG Music Studio/Core/GBA/AlphaDream/Mixer.cs
@@ -21,8 +21,8 @@ namespace Kermalis.VGMusicStudio.Core.GBA.AlphaDream
         public Mixer(Config config)
         {
             Config = config;
-            const int sampleRate = 13379; // TODO: Actual value unknown
-            SamplesPerBuffer = 224; // TODO
+            const int sampleRate = 26758; // TODO: Actual value unknown
+            SamplesPerBuffer = 448; // TODO
             SampleRateReciprocal = 1f / sampleRate;
             _samplesReciprocal = 1f / SamplesPerBuffer;
 


### PR DESCRIPTION
Samplerate for AlphaDream's engine sounds like carpet. 

I'm unsure if this was intentional or not to match the original sound, or if there's some other form of technical reason for this, but this would be a nice change as the instruments are much more crisp.  

This PR just doubles it. 