### PR TITLE
Fixed MP2K Pitch Bend Range MIDI event write

### DIFF
--- a/VG Music Studio/Core/GBA/MP2K/Player.cs
+++ b/VG Music Studio/Core/GBA/MP2K/Player.cs
@@ -810,7 +810,9 @@ namespace Kermalis.VGMusicStudio.Core.GBA.MP2K
                             }
                             case PitchBendRangeCommand bendr:
                             {
-                                track.Insert(ticks, new ChannelMessage(ChannelCommand.Controller, trackIndex, 20, bendr.Range));
+                                track.Insert(ticks, new ChannelMessage(ChannelCommand.Controller, trackIndex, (int)ControllerType.RegisteredParameterCoarse, 0));
+                                track.Insert(ticks, new ChannelMessage(ChannelCommand.Controller, trackIndex, (int)ControllerType.RegisteredParameterFine, 0));
+                                track.Insert(ticks, new ChannelMessage(ChannelCommand.Controller, trackIndex, (int)ControllerType.DataEntrySlider, bendr.Range));
                                 break;
                             }
                             case PriorityCommand prio:


### PR DESCRIPTION
Originally, the event was writing with an undefined controller. This fix writes using the RPN controllers (0,0) and coarse data entry of the range (in semitones).