### PR TITLE
[net-6 branch] Reverted alignments in DSELoadSong back to 4s

### DIFF
--- a/VG Music Studio - Core/NDS/DSE/DSELoadedSong.cs
+++ b/VG Music Studio - Core/NDS/DSE/DSELoadedSong.cs
@@ -55,7 +55,7 @@ internal sealed partial class DSELoadedSong : ILoadedSong
 				r.Stream.Position = chunkStart + 0xC;
 				uint chunkLength = r.ReadUInt32();
 				r.Stream.Position += chunkLength;
-				r.Stream.Align(16);
+				r.Stream.Align(4);
 			}
 		}
 	}


### PR DESCRIPTION
I think Kermalis broke this part by accident, whoops lol

SMD track data isn't generated in 16^x, but rather 4^x instead, where as chunks are generated in 16^x

Now DSE should be working again! Yay!